### PR TITLE
Docs Bugfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ script:
   - julia -e 'using Pkg; Pkg.add("Mimi")'
   - julia -e 'using Pkg; Pkg.add("CSVFiles")'
   - julia -e 'using Pkg; Pkg.add("Query")'
+  - julia -e 'using Pkg; Pkg.add("DataFrames")'
+  - julia -e 'using Pkg; Pkg.add("Distributions")'
+  - julia -e 'using Pkg; Pkg.add("Query")'
+  - julia -e 'using Pkg; Pkg.add("Missings")'
 
   - julia --code-coverage=user test/runtests.jl
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ branches:
 script:
   - julia -e 'using Pkg; Pkg.add("Mimi")'
   - julia -e 'using Pkg; Pkg.add("CSVFiles")'
+  - julia -e 'using Pkg; Pkg.add("Query")'
+
   - julia --code-coverage=user test/runtests.jl
 after_success:
   # push coverage results to Codecov

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,9 +12,5 @@ makedocs(
 )
 
 deploydocs(
-    deps = nothing,
-    make = nothing,
-	target = "build",
     repo = "github.com/anthofflab/mimi-page.jl.git",
-    julia = "0.6"
 )

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -35,7 +35,7 @@ To exit the Pkg REPL-mode, simply backspace once to re-enter the Julia REPL.
 
 You only have to run this command once on your machine.
 
-Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles and Missings packages.
+Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles, Query, and Missings packages.
 
 For more information about the Mimi component framework, you can refer to the [Mimi](https://github.com/anthofflab/Mimi.jl) Github repository, which has a documentation and links to various models that are based on Mimi.
 

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -58,8 +58,7 @@ documentation in the Mimi [User Guide](`http://anthofflab.berkeley.edu/Mimi.jl/s
 
 To run the stochastic version of Mimi-PAGE, which uses parameter
 distributions, see the `mcs.jl` file in the src folder and the documentation for
-Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The 
-simplest version of runningn the stochastic version would be carried out as follows:
+Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The simplest version of the stochastic can be implemented as follows:
 ```julia
 julia> include(mcs.jl)
 julia> do_monte_carlo_runs(1000) #1000 runs

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -33,7 +33,7 @@ julia> ]add Mimi
 
 To exit the Pkg REPL-mode, simply backspace once to re-enter the Julia REPL.
 
-You only have to run this command once on your machine.
+You only have to run this (whichever method you choose) once on your machine.
 
 Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles, Query, and Missings packages.
 
@@ -50,12 +50,21 @@ runs the deterministic version of Mimi-PAGE with central parameter
 estimates. The `getpage` function used in that file create the
 initialized PAGE model. You can print the model, by typing `m`, which
 returns a list of components and each of their incoming parameters and
-outgoing variables. Results can be viewed by running `m[:ComponentName, :VariableName]` for the desired component and variable.
+outgoing variables. Results can be viewed by running `m[:ComponentName, :VariableName]` 
+for the desired component and variable. You may also explore the results graphically
+by running `explore(m)` to view all variables and parameters, or `explore(m, :VariableName)`
+for just one. For more details on the graphical interface of Mimi look to the
+documentation in the Mimi [User Guide](`http://anthofflab.berkeley.edu/Mimi.jl/stable/userguide/#Plotting-and-the-Explorer-UI-1`).
 
 To run the stochastic version of Mimi-PAGE, which uses parameter
 distributions, see the `mcs.jl` file in the src folder and the documentation for
-Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The
-current Monte Carlo process outputs a selection of variables that are
+Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The 
+simplest version of runningn the stochastic version would be carried out as follows:
+```julia
+julia> include(mcs.jl)
+julia> do_monte_carlo_runs(1000) #1000 runs
+```
+The current Monte Carlo process outputs a selection of variables that are
 important for validation, but these can be modified by the user if
 desired. For more information, see the [Technical Guide](technicaluserguide.md).
 

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -5,7 +5,7 @@ This guide will briefly explain how to install Julia and Mimi-PAGE.
 ## Installing Julia
 
 Mimi-PAGE requires the programming
-language [Julia](http://julialang.org/), version 0.6 or later, to
+language [Julia](http://julialang.org/), version 1.0 or later, to
 run. Download and install the current release from the Julia [download page](http://julialang.org/downloads/).
 
 ### Julia Editor Support

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -22,8 +22,17 @@ The Mimi-PAGE model is written for the Mimi modeling framework, which
 needs to be installed as a standard Julia package.
 Once Julia is installed, start Julia and you should see a Julia command prompt. To install the Mimi package, issue the following command:
 ```julia
+julia> using Pkg
 julia> Pkg.add("Mimi")
 ```
+
+Or, alternatively enter the (Pkg REPL-mode)[https://docs.julialang.org/en/v1/stdlib/Pkg/index.html] is from the Julia REPL using the key `]`.  After typing this, you may proceed with `Pkg` methods without using `Pkg.`.  This would look like:
+```julia
+julia> ]add Mimi
+```
+
+To exit the Pkg REPL-mode, simply backspace once to re-enter the Julia REPL.
+
 You only have to run this command once on your machine.
 
 Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles and Missings packages.
@@ -44,11 +53,11 @@ returns a list of components and each of their incoming parameters and
 outgoing variables. Results can be viewed by running `m[:ComponentName, :VariableName]` for the desired component and variable.
 
 To run the stochastic version of Mimi-PAGE, which uses parameter
-distributions, see the `mcs.jl` file in the src folder. The
+distributions, see the `mcs.jl` file in the src folder and the documentation for
+Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The
 current Monte Carlo process outputs a selection of variables that are
 important for validation, but these can be modified by the user if
-desired. The user can also set the number of Monte Carlo runs in
-montecarlo.jl. For more information, see the [Technical Guide](technicaluserguide.md).
+desired. For more information, see the [Technical Guide](technicaluserguide.md).
 
 ## Troubleshooting
 

--- a/docs/src/technicaluserguide.md
+++ b/docs/src/technicaluserguide.md
@@ -48,7 +48,7 @@ policies can be added in the same fashion.
 
 ## Code format
 
- - The code is written in Julia (v0.6 or greater).
+ - The code is written in Julia (v1.0 or greater).
  - The data are in CSV format for easy portability and manipulation.
  - The docs are in Markdown format for readability on github.
 


### PR DESCRIPTION
refers to Issue #162 

This PR fixes the following small documentation errors:

- Fix README links: README documentation links were broken and I'm guessing this is because because the build was failing, I have now fixed the build failure by adding some `Pkg.add` statements to `travis.yml`, and the links (should) be fixed, **although we won't know until this is merged**
- Update the Monte Carlo instructions in `getting started.md`
- Add specific instructions in the documentation that align better with Julia 1.0, namely (1) refer to Julia 1.0 not Julia 0.6 (2) remind users of either typing `using Pkg; Pkg.add` or using the Pkg-Mode REPL with `]`;  [x] `using Pkg` before `Pkg.add`