### PR TITLE
Split the Abatement Cost Component (UPDATED VERSION)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ script:
   - julia -e 'using Pkg; Pkg.add("Mimi")'
   - julia -e 'using Pkg; Pkg.add("CSVFiles")'
   - julia -e 'using Pkg; Pkg.add("Query")'
+  - julia -e 'using Pkg; Pkg.add("DataFrames")'
+  - julia -e 'using Pkg; Pkg.add("Distributions")'
+  - julia -e 'using Pkg; Pkg.add("Query")'
+  - julia -e 'using Pkg; Pkg.add("Missings")'
 
   - julia --code-coverage=user test/runtests.jl
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ branches:
 script:
   - julia -e 'using Pkg; Pkg.add("Mimi")'
   - julia -e 'using Pkg; Pkg.add("CSVFiles")'
+  - julia -e 'using Pkg; Pkg.add("Query")'
+
   - julia --code-coverage=user test/runtests.jl
 after_success:
   # push coverage results to Codecov

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,9 +12,5 @@ makedocs(
 )
 
 deploydocs(
-    deps = nothing,
-    make = nothing,
-	target = "build",
     repo = "github.com/anthofflab/mimi-page.jl.git",
-    julia = "0.6"
 )

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -35,7 +35,7 @@ To exit the Pkg REPL-mode, simply backspace once to re-enter the Julia REPL.
 
 You only have to run this command once on your machine.
 
-Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles and Missings packages.
+Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles, Query, and Missings packages.
 
 For more information about the Mimi component framework, you can refer to the [Mimi](https://github.com/anthofflab/Mimi.jl) Github repository, which has a documentation and links to various models that are based on Mimi.
 

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -33,7 +33,7 @@ julia> ]add Mimi
 
 To exit the Pkg REPL-mode, simply backspace once to re-enter the Julia REPL.
 
-You only have to run this command once on your machine.
+You only have to run this (whichever method you choose) once on your machine.
 
 Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles, Query, and Missings packages.
 
@@ -50,12 +50,21 @@ runs the deterministic version of Mimi-PAGE with central parameter
 estimates. The `getpage` function used in that file create the
 initialized PAGE model. You can print the model, by typing `m`, which
 returns a list of components and each of their incoming parameters and
-outgoing variables. Results can be viewed by running `m[:ComponentName, :VariableName]` for the desired component and variable.
+outgoing variables. Results can be viewed by running `m[:ComponentName, :VariableName]` 
+for the desired component and variable. You may also explore the results graphically
+by running `explore(m)` to view all variables and parameters, or `explore(m, :VariableName)`
+for just one. For more details on the graphical interface of Mimi look to the
+documentation in the Mimi [User Guide](`http://anthofflab.berkeley.edu/Mimi.jl/stable/userguide/#Plotting-and-the-Explorer-UI-1`).
 
 To run the stochastic version of Mimi-PAGE, which uses parameter
 distributions, see the `mcs.jl` file in the src folder and the documentation for
-Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The
-current Monte Carlo process outputs a selection of variables that are
+Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The 
+simplest version of runningn the stochastic version would be carried out as follows:
+```julia
+julia> include(mcs.jl)
+julia> do_monte_carlo_runs(1000) #1000 runs
+```
+The current Monte Carlo process outputs a selection of variables that are
 important for validation, but these can be modified by the user if
 desired. For more information, see the [Technical Guide](technicaluserguide.md).
 

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -5,7 +5,7 @@ This guide will briefly explain how to install Julia and Mimi-PAGE.
 ## Installing Julia
 
 Mimi-PAGE requires the programming
-language [Julia](http://julialang.org/), version 0.6 or later, to
+language [Julia](http://julialang.org/), version 1.0 or later, to
 run. Download and install the current release from the Julia [download page](http://julialang.org/downloads/).
 
 ### Julia Editor Support

--- a/docs/src/gettingstarted.md
+++ b/docs/src/gettingstarted.md
@@ -22,8 +22,17 @@ The Mimi-PAGE model is written for the Mimi modeling framework, which
 needs to be installed as a standard Julia package.
 Once Julia is installed, start Julia and you should see a Julia command prompt. To install the Mimi package, issue the following command:
 ```julia
+julia> using Pkg
 julia> Pkg.add("Mimi")
 ```
+
+Or, alternatively enter the (Pkg REPL-mode)[https://docs.julialang.org/en/v1/stdlib/Pkg/index.html] is from the Julia REPL using the key `]`.  After typing this, you may proceed with `Pkg` methods without using `Pkg.`.  This would look like:
+```julia
+julia> ]add Mimi
+```
+
+To exit the Pkg REPL-mode, simply backspace once to re-enter the Julia REPL.
+
 You only have to run this command once on your machine.
 
 Mimi-PAGE also requires the Distributions, DataFrames, CSVFiles and Missings packages.
@@ -44,11 +53,11 @@ returns a list of components and each of their incoming parameters and
 outgoing variables. Results can be viewed by running `m[:ComponentName, :VariableName]` for the desired component and variable.
 
 To run the stochastic version of Mimi-PAGE, which uses parameter
-distributions, see the `mcs.jl` file in the src folder. The
+distributions, see the `mcs.jl` file in the src folder and the documentation for
+Mimi Monte Carlo support [here](https://github.com/anthofflab/Mimi.jl/blob/master/docs/src/internals/montecarlo.md). The
 current Monte Carlo process outputs a selection of variables that are
 important for validation, but these can be modified by the user if
-desired. The user can also set the number of Monte Carlo runs in
-montecarlo.jl. For more information, see the [Technical Guide](technicaluserguide.md).
+desired. For more information, see the [Technical Guide](technicaluserguide.md).
 
 ## Troubleshooting
 

--- a/docs/src/technicaluserguide.md
+++ b/docs/src/technicaluserguide.md
@@ -48,7 +48,7 @@ policies can be added in the same fashion.
 
 ## Code format
 
- - The code is written in Julia (v0.6 or greater).
+ - The code is written in Julia (v1.0 or greater).
  - The data are in CSV format for easy portability and manipulation.
  - The docs are in Markdown format for readability on github.
 

--- a/src/components/AbatementCostParameters.jl
+++ b/src/components/AbatementCostParameters.jl
@@ -1,0 +1,174 @@
+include("../utils/mctools.jl")
+
+@defcomp AbatementCostParameters begin
+
+    region = Index()
+    y_year = Parameter(index=[time], unit="year")
+    y_year_0 = Parameter(unit="year", default = 2008.)
+
+    #gas inputs
+    emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = Parameter(unit="%")
+    q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = Parameter(unit="% of BAU emissions")
+    c0init_MostNegativeCostCutbackinBaseYear = Parameter(unit="\$/ton")
+    qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = Parameter(unit="% of BAU emissions")
+    cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = Parameter(unit="\$/ton")
+    ies_InitialExperienceStockofCutbacks = Parameter(unit= "Million ton")
+    e0_baselineemissions = Parameter(index=[region], unit= "Mtonne/year")
+
+    #regional inputs
+    emitf_uncertaintyinBAUemissfactor = Parameter(index=[region], unit= "none")
+    q0f_negativecostpercentagefactor = Parameter(index=[region], unit="none")
+    cmaxf_maxcostfactor = Parameter(index=[region], unit="none")
+
+    bau_businessasusualemissions = Parameter(index=[time, region], unit = "%")
+    yagg = Parameter(index=[time], unit="year") # from equity weighting
+
+    #inputs with single, uncertain values
+    q0propmult_cutbacksatnegativecostinfinalyear = Parameter(unit="none", default=.733333333333333334)
+    qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear = Parameter(unit="none", default=1.2666666666666666)
+    c0mult_mostnegativecostinfinalyear = Parameter(unit="none", default=.8333333333333334)
+    curve_below_curvatureofMACcurvebelowzerocost = Parameter(unit="none", default=.5)
+    curve_above_curvatureofMACcurveabovezerocost = Parameter(unit="none", default=.4)
+    cross_experiencecrossoverratio = Parameter(unit="none", default=.2)
+    learn_learningrate = Parameter(unit="none", default=.2)
+    automult_autonomoustechchange = Parameter(unit="none", default=.65)
+    equity_prop_equityweightsproportion = Parameter(unit="none", default=1.)
+
+    # Inputs from other components
+    cbe_absoluteemissionreductions = Parameter(index=[time, region], unit="Mtonne") #TODO: default here?
+    
+    #Variables
+    emit_UncertaintyinBAUEmissFactor = Variable(index=[region], unit = "%")
+    q0propinit_CutbacksinNegativeCostinBaseYear = Variable(index=[region], unit= "% of BAU emissions")
+    cmaxinit_MaxCutbackCostinBaseYear = Variable(index=[region], unit = "\$/ton")
+    zc_zerocostemissions = Variable(index=[time, region], unit= "%")
+    cumcbe_cumulativereductionssincebaseyear = Variable(index=[time, region], unit="Mtonne")
+    cumcbe_g_totalreductions = Variable(index=[time], unit="Mtonne")
+    learnfac_learning= Variable(index=[time, region], unit= "none")
+    auto = Variable(unit="% per year")
+    autofac = Variable(index=[time], unit= "% per year")
+    c0g = Variable(unit= "% per year")
+    c0 = Variable(index=[time], unit= "\$/ton")
+    qmaxminusq0propg = Variable(unit= "% per year")
+    qmaxminusq0prop = Variable(unit = "% of BAU emissions")
+    q0propg = Variable(unit = "% per year")
+    q0prop = Variable(index=[time, region], unit="% of BAU emissions")
+    q0_absolutecutbacksatnegativecost = Variable(index=[time, region], unit= "Mtonne")
+    qmax_maxreferencereductions = Variable(index=[time, region], unit="Mtonne")
+    cmax = Variable(index=[time,region], unit = "\$/tonne")
+    blo = Variable(index=[time, region], unit = "per Mtonne")
+    alo = Variable(index=[time, region], unit = "\$/tonne")
+    bhi = Variable(index=[time, region], unit = "per Mtonne")
+    ahi = Variable(index=[time, region], unit = "\$/tonne")
+    mc_marginalcost = Variable(index=[time, region], unit = "\$/tonne")
+    tcq0 = Variable(index=[time, region], unit = "\$million")
+    tc_totalcost = Variable(index=[time, region], unit= "\$million")
+
+    function run_timestep(p, v, d, t)
+
+        for r in d.region
+            v.emit_UncertaintyinBAUEmissFactor[r] = p.emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear *
+                p.emitf_uncertaintyinBAUemissfactor[r]
+            v.q0propinit_CutbacksinNegativeCostinBaseYear[r] = p.q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear *
+                p.q0f_negativecostpercentagefactor[r]
+            v.cmaxinit_MaxCutbackCostinBaseYear[r] = p.cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear *
+                p.cmaxf_maxcostfactor[r]
+
+            v.zc_zerocostemissions[t,r] = (1+v.emit_UncertaintyinBAUEmissFactor[r]/100 * (p.y_year[t]-p.y_year_0)/(p.y_year[end]-p.y_year_0)) * p.bau_businessasusualemissions[t,r]
+
+            if isfirst(t)
+                v.cumcbe_cumulativereductionssincebaseyear[t,r] = 0.
+            else
+                v.cumcbe_cumulativereductionssincebaseyear[t,r] = v.cumcbe_cumulativereductionssincebaseyear[t-1, r] + p.cbe_absoluteemissionreductions[t-1, r] * p.yagg[t-1]
+            end
+        end
+        
+        v.cumcbe_g_totalreductions[t] = sum(v.cumcbe_cumulativereductionssincebaseyear[t,:])
+
+        v.auto = (1-p.automult_autonomoustechchange^(1/(p.y_year[end]-p.y_year_0)))*100
+        v.autofac[t] = (1-v.auto/100)^(p.y_year[t] - p.y_year_0)
+
+        v.c0g = (p.c0mult_mostnegativecostinfinalyear^(1/(p.y_year[end]-p.y_year_0))-1)*100
+        v.c0[t] = p.c0init_MostNegativeCostCutbackinBaseYear* (1+v.c0g/100)^(p.y_year[t]-p.y_year_0)
+
+        v.qmaxminusq0propg = (p.qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear ^(1/(p.y_year[end]-p.y_year_0))- 1)* 100
+        v.qmaxminusq0prop = p.qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear * (1+ v.qmaxminusq0propg/100)^(p.y_year[t]-p.y_year_0)
+
+        v.q0propg = (p.q0propmult_cutbacksatnegativecostinfinalyear^(1/(p.y_year[end]-p.y_year_0))-1)*100
+
+        for r in d.region
+            v.learnfac_learning[t,r] = ((p.cross_experiencecrossoverratio *v.cumcbe_g_totalreductions[t]+ (1-p.cross_experiencecrossoverratio)*v.cumcbe_cumulativereductionssincebaseyear[t,r] + p.ies_InitialExperienceStockofCutbacks)/ p.ies_InitialExperienceStockofCutbacks)^ -(log(1/(1-p.learn_learningrate))/log(2))
+
+            v.q0prop[t,r] = v.q0propinit_CutbacksinNegativeCostinBaseYear[r]* (1+v.q0propg/100)^(p.y_year[t]-p.y_year_0)
+
+            v.q0_absolutecutbacksatnegativecost[t,r]= (v.q0prop[t,r]/100)* (v.zc_zerocostemissions[t,r]/100) * p.e0_baselineemissions[r]
+
+            v.qmax_maxreferencereductions[t,r] = (v.qmaxminusq0prop/100) * (v.zc_zerocostemissions[t,r]/100)* p.e0_baselineemissions[r] + v.q0_absolutecutbacksatnegativecost[t,r]
+
+            v.cmax[t,r] = v.cmaxinit_MaxCutbackCostinBaseYear[r] * v.learnfac_learning[t,r]* v.autofac[t]
+
+            v.blo[t,r] = -2*log((1+p.curve_below_curvatureofMACcurvebelowzerocost)/(1-p.curve_below_curvatureofMACcurvebelowzerocost))/ v.q0_absolutecutbacksatnegativecost[t,r]
+            v.alo[t,r] = v.c0[t]/(exp(-v.blo[t,r]*v.q0_absolutecutbacksatnegativecost[t,r])-1)
+            v.bhi[t,r] = 2*log((1+p.curve_above_curvatureofMACcurveabovezerocost)/(1-p.curve_above_curvatureofMACcurveabovezerocost))/ (v.qmax_maxreferencereductions[t,r] - v.q0_absolutecutbacksatnegativecost[t,r])
+            v.ahi[t,r] = v.cmax[t,r]/ (exp(v.bhi[t,r]*(v.qmax_maxreferencereductions[t,r]-v.q0_absolutecutbacksatnegativecost[t,r]))-1)
+        end
+    end
+end
+
+function addabatementcostparameters(model::Model, class::Symbol, policy::String="policy-a")
+    componentname = Symbol("AbatementCostParameters$class")
+    abatementcostscomp = addcomponent(model, AbatementCostParameters, componentname)
+
+    abatementcostscomp[:q0propmult_cutbacksatnegativecostinfinalyear] = .733333333333333334
+    abatementcostscomp[:qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear] = 1.2666666666666666
+    abatementcostscomp[:c0mult_mostnegativecostinfinalyear] = .8333333333333334
+    abatementcostscomp[:curve_below_curvatureofMACcurvebelowzerocost] = .5
+    abatementcostscomp[:curve_above_curvatureofMACcurveabovezerocost] = .4
+    abatementcostscomp[:cross_experiencecrossoverratio] = .2
+    abatementcostscomp[:learn_learningrate] = .2
+    abatementcostscomp[:automult_autonomoustechchange] = .65
+    abatementcostscomp[:equity_prop_equityweightsproportion] = 1.
+    abatementcostscomp[:y_year_0] = 2008.
+
+    if class == :CO2
+        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 8.333333333333334)
+        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 20.)
+        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -233.333333333333)
+        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 70.)
+        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 400.)
+        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 150000.)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineCO2emissions.csv"))
+        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model, "data/bau_co2emissions.csv"))
+    elseif class == :CH4
+        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 25.)
+        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 10.)
+        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -4333.3333333333333)
+        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 51.66666666666666664)
+        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 6333.33333333333)
+        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 2000.)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineCH4emissions.csv"))
+        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model, "data/bau_ch4emissions.csv"))
+    elseif class == :N2O
+        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 0.)
+        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 10.)
+        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -7333.333333333333)
+        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 51.66666666666666664)
+        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 27333.3333333333)
+        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 53.3333333333333)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineN2Oemissions.csv"))
+        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model, "data/bau_n2oemissions.csv"))
+    elseif class == :Lin
+        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 0.)
+        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 10.)
+        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -233.333333333333)
+        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 70.)
+        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 333.333333333333)
+        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 2000.)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model,"data/e0_baselineLGemissions.csv"))
+        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model,"data/bau_linemissions.csv"))
+    else
+        error("Unknown class of abatement costs.")
+    end
+
+    return abatementcostscomp
+end

--- a/src/components/AbatementCosts.jl
+++ b/src/components/AbatementCosts.jl
@@ -1,64 +1,27 @@
+include("../utils/mctools.jl")
+
 using Mimi
 
 @defcomp AbatementCosts begin
     region = Index()
-    y_year = Parameter(index=[time], unit="year")
-    y_year_0 = Parameter(unit="year", default=2008.)
 
-    #gas inputs
-    emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear = Parameter(unit="%")
-    q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear = Parameter(unit="% of BAU emissions")
-    c0init_MostNegativeCostCutbackinBaseYear = Parameter(unit="\$/ton")
-    qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear = Parameter(unit="% of BAU emissions")
-    cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear = Parameter(unit="\$/ton")
-    ies_InitialExperienceStockofCutbacks = Parameter(unit= "Million ton")
-    er_emissionsgrowth = Parameter(index=[time, region], unit= "%")
+   # From the AbatementCostParameters
+    zc_zerocostemissions = Parameter(index=[time, region], unit= "%")
+    q0_absolutecutbacksatnegativecost = Parameter(index=[time, region], unit= "Mtonne")
+    blo = Parameter(index=[time, region], unit = "per Mtonne")
+    alo = Parameter(index=[time, region], unit = "\$/tonne")
+    bhi = Parameter(index=[time, region], unit = "per Mtonne")
+    ahi = Parameter(index=[time, region], unit = "\$/tonne")
+
+    # Driver of abatement costs
     e0_baselineemissions = Parameter(index=[region], unit= "Mtonne/year")
+    er_emissionsgrowth = Parameter(index=[time, region], unit= "%")
 
-    #regional inputs
-    emitf_uncertaintyinBAUemissfactor = Parameter(index=[region], unit= "none")
-    q0f_negativecostpercentagefactor = Parameter(index=[region], unit="none")
-    cmaxf_maxcostfactor = Parameter(index=[region], unit="none")
-
-    bau_businessasusualemissions = Parameter(index=[time, region], unit = "%")
-    yagg = Parameter(index=[time], unit="year") # from equity weighting
-
-    #inputs with single, uncertain values
-    q0propmult_cutbacksatnegativecostinfinalyear = Parameter(unit="none", default=.733333333333333334)
-    qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear = Parameter(unit="none", default=1.2666666666666666)
-    c0mult_mostnegativecostinfinalyear = Parameter(unit="none", default=.8333333333333334)
-    curve_below_curvatureofMACcurvebelowzerocost = Parameter(unit="none", default=.5)
-    curve_above_curvatureofMACcurveabovezerocost = Parameter(unit="none", default=.4)
-    cross_experiencecrossoverratio = Parameter(unit="none", default=.2)
-    learn_learningrate = Parameter(unit="none", default=.2)
-    automult_autonomoustechchange = Parameter(unit="none", default=.65)
-    equity_prop_equityweightsproportion = Parameter(unit="none", default=1.)
-
-    #Variables
-    emit_UncertaintyinBAUEmissFactor = Variable(index=[region], unit = "%")
-    q0propinit_CutbacksinNegativeCostinBaseYear = Variable(index=[region], unit= "% of BAU emissions")
-    cmaxinit_MaxCutbackCostinBaseYear = Variable(index=[region], unit = "\$/ton")
-    zc_zerocostemissions = Variable(index=[time, region], unit= "%")
+    # Intermediate outputs
     cb_reductionsfromzerocostemissions = Variable(index=[time, region], unit= "%")
-    cbe_absoluteemissionreductions = Variable(index=[time, region], unit="Mtonne")
-    cumcbe_cumulativereductionssincebaseyear = Variable(index=[time, region], unit="Mtonne")
-    cumcbe_g_totalreductions = Variable(index=[time], unit="Mtonne")
-    learnfac_learning= Variable(index=[time, region], unit= "none")
-    auto = Variable(unit="% per year")
-    autofac = Variable(index=[time], unit= "% per year")
-    c0g = Variable(unit= "% per year")
-    c0 = Variable(index=[time], unit= "\$/ton")
-    qmaxminusq0propg = Variable(unit= "% per year")
-    qmaxminusq0prop = Variable(unit = "% of BAU emissions")
-    q0propg = Variable(unit = "% per year")
-    q0prop = Variable(index=[time, region], unit="% of BAU emissions")
-    q0_absolutecutbacksatnegativecost = Variable(index=[time, region], unit= "Mtonne")
-    qmax_maxreferencereductions = Variable(index=[time, region], unit="Mtonne")
-    cmax = Variable(index=[time,region], unit = "\$/tonne")
-    blo = Variable(index=[time, region], unit = "per Mtonne")
-    alo = Variable(index=[time, region], unit = "\$/tonne")
-    bhi = Variable(index=[time, region], unit = "per Mtonne")
-    ahi = Variable(index=[time, region], unit = "\$/tonne")
+    cbe_absoluteemissionreductions = Variable(index=[time, region], unit="Mtonne") # Goes to AbatementCostParameters
+
+    # Main costs results
     mc_marginalcost = Variable(index=[time, region], unit = "\$/tonne")
     tcq0 = Variable(index=[time, region], unit = "\$million")
     tc_totalcost = Variable(index=[time, region], unit= "\$million")
@@ -66,73 +29,28 @@ using Mimi
     function run_timestep(p, v, d, t)
 
         for r in d.region
-            v.emit_UncertaintyinBAUEmissFactor[r] = p.emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear *
-                p.emitf_uncertaintyinBAUemissfactor[r]
-            v.q0propinit_CutbacksinNegativeCostinBaseYear[r] = p.q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear *
-                p.q0f_negativecostpercentagefactor[r]
-            v.cmaxinit_MaxCutbackCostinBaseYear[r] = p.cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear *
-                p.cmaxf_maxcostfactor[r]
-
-            v.zc_zerocostemissions[t,r] = (1+v.emit_UncertaintyinBAUEmissFactor[r]/100 * (p.y_year[t]-p.y_year_0)/(p.y_year[end]-p.y_year_0)) * p.bau_businessasusualemissions[t,r]
-
-            v.cb_reductionsfromzerocostemissions[t,r] = max(v.zc_zerocostemissions[t,r] - p.er_emissionsgrowth[t,r], 0)
-
+            v.cb_reductionsfromzerocostemissions[t,r] = max(p.zc_zerocostemissions[t,r] - p.er_emissionsgrowth[t,r], 0)
             v.cbe_absoluteemissionreductions[t,r] = v.cb_reductionsfromzerocostemissions[t,r]* p.e0_baselineemissions[r]/100
 
-            if is_first(t)
-                v.cumcbe_cumulativereductionssincebaseyear[t,r] = 0.
+            if v.cbe_absoluteemissionreductions[t,r]< p.q0_absolutecutbacksatnegativecost[t,r]
+                v.mc_marginalcost[t,r] = p.alo[t,r]* (exp(p.blo[t,r]*(v.cbe_absoluteemissionreductions[t,r]- p.q0_absolutecutbacksatnegativecost[t,r]))-1)
             else
-                v.cumcbe_cumulativereductionssincebaseyear[t,r] = v.cumcbe_cumulativereductionssincebaseyear[t-1, r] + v.cbe_absoluteemissionreductions[t-1, r] * p.yagg[t-1]
-            end
-        end
-            v.cumcbe_g_totalreductions[t] = sum(v.cumcbe_cumulativereductionssincebaseyear[t,:])
-
-            v.auto = (1-p.automult_autonomoustechchange^(1/(p.y_year[end]-p.y_year_0)))*100
-            v.autofac[t] = (1-v.auto/100)^(p.y_year[t] - p.y_year_0)
-
-            v.c0g = (p.c0mult_mostnegativecostinfinalyear^(1/(p.y_year[end]-p.y_year_0))-1)*100
-            v.c0[t] = p.c0init_MostNegativeCostCutbackinBaseYear* (1+v.c0g/100)^(p.y_year[t]-p.y_year_0)
-
-            v.qmaxminusq0propg = (p.qmax_minus_q0propmult_maxcutbacksatpositivecostinfinalyear ^(1/(p.y_year[end]-p.y_year_0))- 1)* 100
-            v.qmaxminusq0prop = p.qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear * (1+ v.qmaxminusq0propg/100)^(p.y_year[t]-p.y_year_0)
-
-            v.q0propg = (p.q0propmult_cutbacksatnegativecostinfinalyear^(1/(p.y_year[end]-p.y_year_0))-1)*100
-
-        for r in d.region
-            v.learnfac_learning[t,r] = ((p.cross_experiencecrossoverratio *v.cumcbe_g_totalreductions[t]+ (1-p.cross_experiencecrossoverratio)*v.cumcbe_cumulativereductionssincebaseyear[t,r] + p.ies_InitialExperienceStockofCutbacks)/ p.ies_InitialExperienceStockofCutbacks)^ -(log(1/(1-p.learn_learningrate))/log(2))
-
-            v.q0prop[t,r] = v.q0propinit_CutbacksinNegativeCostinBaseYear[r]* (1+v.q0propg/100)^(p.y_year[t]-p.y_year_0)
-
-            v.q0_absolutecutbacksatnegativecost[t,r]= (v.q0prop[t,r]/100)* (v.zc_zerocostemissions[t,r]/100) * p.e0_baselineemissions[r]
-
-            v.qmax_maxreferencereductions[t,r] = (v.qmaxminusq0prop/100) * (v.zc_zerocostemissions[t,r]/100)* p.e0_baselineemissions[r] + v.q0_absolutecutbacksatnegativecost[t,r]
-
-            v.cmax[t,r] = v.cmaxinit_MaxCutbackCostinBaseYear[r] * v.learnfac_learning[t,r]* v.autofac[t]
-
-            v.blo[t,r] = -2*log((1+p.curve_below_curvatureofMACcurvebelowzerocost)/(1-p.curve_below_curvatureofMACcurvebelowzerocost))/ v.q0_absolutecutbacksatnegativecost[t,r]
-            v.alo[t,r] = v.c0[t]/(exp(-v.blo[t,r]*v.q0_absolutecutbacksatnegativecost[t,r])-1)
-            v.bhi[t,r] = 2*log((1+p.curve_above_curvatureofMACcurveabovezerocost)/(1-p.curve_above_curvatureofMACcurveabovezerocost))/ (v.qmax_maxreferencereductions[t,r] - v.q0_absolutecutbacksatnegativecost[t,r])
-            v.ahi[t,r] = v.cmax[t,r]/ (exp(v.bhi[t,r]*(v.qmax_maxreferencereductions[t,r]-v.q0_absolutecutbacksatnegativecost[t,r]))-1)
-
-            if v.cbe_absoluteemissionreductions[t,r]< v.q0_absolutecutbacksatnegativecost[t,r]
-                v.mc_marginalcost[t,r] = v.alo[t,r]* (exp(v.blo[t,r]*(v.cbe_absoluteemissionreductions[t,r]- v.q0_absolutecutbacksatnegativecost[t,r]))-1)
-            else
-                v.mc_marginalcost[t,r] = v.ahi[t,r]*(exp(v.bhi[t,r]*(v.cbe_absoluteemissionreductions[t,r]- v.q0_absolutecutbacksatnegativecost[t,r]))-1)
+                v.mc_marginalcost[t,r] = p.ahi[t,r]*(exp(p.bhi[t,r]*(v.cbe_absoluteemissionreductions[t,r]- p.q0_absolutecutbacksatnegativecost[t,r]))-1)
             end
 
-            if v.q0_absolutecutbacksatnegativecost[t,r] == 0.
+            if p.q0_absolutecutbacksatnegativecost[t,r] == 0.
                 v.tcq0[t,r] = 0.
             else
-                v.tcq0[t,r] = (v.alo[t,r]/v.blo[t,r])*(1-exp(-v.blo[t,r]* v.q0_absolutecutbacksatnegativecost[t,r]))- v.alo[t,r]*v.q0_absolutecutbacksatnegativecost[t,r]
+                v.tcq0[t,r] = (p.alo[t,r]/p.blo[t,r])*(1-exp(-p.blo[t,r]* p.q0_absolutecutbacksatnegativecost[t,r]))- p.alo[t,r]*p.q0_absolutecutbacksatnegativecost[t,r]
             end
 
-            if v.cbe_absoluteemissionreductions[t,r]<v.q0_absolutecutbacksatnegativecost[t,r]
-                v.tc_totalcost[t,r] = (v.alo[t,r]/v.blo[t,r])*(exp(v.blo[t,r]*(v.cbe_absoluteemissionreductions[t,r]- v.q0_absolutecutbacksatnegativecost[t,r]))- exp(-v.blo[t,r]*v.q0_absolutecutbacksatnegativecost[t,r])) - v.alo[t,r]*v.cbe_absoluteemissionreductions[t,r]
+            if v.cbe_absoluteemissionreductions[t,r]<p.q0_absolutecutbacksatnegativecost[t,r]
+                v.tc_totalcost[t,r] = (p.alo[t,r]/p.blo[t,r])*(exp(p.blo[t,r]*(v.cbe_absoluteemissionreductions[t,r]- p.q0_absolutecutbacksatnegativecost[t,r]))- exp(-p.blo[t,r]*p.q0_absolutecutbacksatnegativecost[t,r])) - p.alo[t,r]*v.cbe_absoluteemissionreductions[t,r]
             else
-                v.tc_totalcost[t,r] = (v.ahi[t,r]/v.bhi[t,r])* (exp(v.bhi[t,r]*(v.cbe_absoluteemissionreductions[t,r]-v.q0_absolutecutbacksatnegativecost[t,r]))-1) - v.ahi[t,r]*(v.cbe_absoluteemissionreductions[t,r] - v.q0_absolutecutbacksatnegativecost[t,r]) + v.tcq0[t,r]
+                v.tc_totalcost[t,r] = (p.ahi[t,r]/p.bhi[t,r])* (exp(p.bhi[t,r]*(v.cbe_absoluteemissionreductions[t,r]-p.q0_absolutecutbacksatnegativecost[t,r]))-1) - p.ahi[t,r]*(v.cbe_absoluteemissionreductions[t,r] - p.q0_absolutecutbacksatnegativecost[t,r]) + v.tcq0[t,r]
             end
-        end
-    end
+        end 
+    end       
 end
 
 function addabatementcosts(model::Model, class::Symbol, policy::String="policy-a")
@@ -140,64 +58,36 @@ function addabatementcosts(model::Model, class::Symbol, policy::String="policy-a
     abatementcostscomp = add_comp!(model, AbatementCosts, componentname)
 
     if class == :CO2
-        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 8.333333333333334)
-        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 20.)
-        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -233.333333333333)
-        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 70.)
-        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 400.)
-        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 150000.)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineCO2emissions.csv"))
         if policy == "policy-a"
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model, "data/er_CO2emissionsgrowth.csv"))
         else
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model, "data/$policy/er_CO2emissionsgrowth.csv"))
         end
-        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineCO2emissions.csv"))
-        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model, "data/bau_co2emissions.csv"))
     elseif class == :CH4
-        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 25.)
-        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 10.)
-        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -4333.3333333333333)
-        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 51.66666666666666664)
-        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 6333.33333333333)
-        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 2000.)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineCH4emissions.csv"))
         if policy == "policy-a"
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model, "data/er_CH4emissionsgrowth.csv"))
         else
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model, "data/$policy/er_CH4emissionsgrowth.csv"))
         end
-        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineCH4emissions.csv"))
-        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model, "data/bau_ch4emissions.csv"))
     elseif class == :N2O
-        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 0.)
-        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 10.)
-        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -7333.333333333333)
-        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 51.66666666666666664)
-        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 27333.3333333333)
-        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 53.3333333333333)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineN2Oemissions.csv"))
         if policy == "policy-a"
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model, "data/er_N2Oemissionsgrowth.csv"))
         else
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model, "data/$policy/er_N2Oemissionsgrowth.csv"))
         end
-        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model, "data/e0_baselineN2Oemissions.csv"))
-        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model, "data/bau_n2oemissions.csv"))
     elseif class == :Lin
-        setdistinctparameter(model, componentname, :emit_UncertaintyinBAUEmissFactorinFocusRegioninFinalYear, 0.)
-        setdistinctparameter(model, componentname, :q0propinit_CutbacksinNegativeCostinFocusRegioninBaseYear, 10.)
-        setdistinctparameter(model, componentname, :c0init_MostNegativeCostCutbackinBaseYear, -233.333333333333)
-        setdistinctparameter(model, componentname, :qmaxminusq0propinit_MaxCutbackCostatPositiveCostinBaseYear, 70.)
-        setdistinctparameter(model, componentname, :cmaxinit_MaximumCutbackCostinFocusRegioninBaseYear, 333.333333333333)
-        setdistinctparameter(model, componentname, :ies_InitialExperienceStockofCutbacks, 2000.)
+        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model,"data/e0_baselineLGemissions.csv"))
         if policy == "policy-a"
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model,"data/er_LGemissionsgrowth.csv"))
         else
             setdistinctparameter(model, componentname, :er_emissionsgrowth, readpagedata(model,"data/$policy/er_LGemissionsgrowth.csv"))
         end
-        setdistinctparameter(model, componentname, :e0_baselineemissions, readpagedata(model,"data/e0_baselineLGemissions.csv"))
-        setdistinctparameter(model, componentname, :bau_businessasusualemissions, readpagedata(model,"data/bau_linemissions.csv"))
     else
         error("Unknown class of abatement costs.")
     end
-
+    
     return abatementcostscomp
 end

--- a/src/getpagefunction.jl
+++ b/src/getpagefunction.jl
@@ -25,6 +25,7 @@ include("components/NonMarketDamages.jl")
 include("components/Discontinuity.jl")
 include("components/AdaptationCosts.jl")
 include("components/SLRDamages.jl")
+include("components/AbatementCostParameters.jl")
 include("components/AbatementCosts.jl")
 include("components/TotalAbatementCosts.jl")
 include("components/TotalAdaptationCosts.jl")
@@ -56,6 +57,11 @@ function buildpage(m::Model, policy::String="policy-a")
     add_comp!(m, GDP)
 
     #Abatement Costs
+    abatementcostparameters_CO2 = addabatementcostparameters(m, :CO2, policy)
+    abatementcostparameters_CH4 = addabatementcostparameters(m, :CH4, policy)
+    abatementcostparameters_N2O = addabatementcostparameters(m, :N2O, policy)
+    abatementcostparameters_Lin = addabatementcostparameters(m, :Lin, policy)
+
     abatementcosts_CO2 = addabatementcosts(m, :CO2, policy)
     abatementcosts_CH4 = addabatementcosts(m, :CH4, policy)
     abatementcosts_N2O = addabatementcosts(m, :N2O, policy)
@@ -116,10 +122,25 @@ function buildpage(m::Model, policy::String="policy-a")
 
     connect_param!(m, :GDP => :pop_population, :Population => :pop_population)
 
-    connect_param!(m, :AbatementCostsCO2 => :yagg, :GDP => :yagg_periodspan)
-    connect_param!(m, :AbatementCostsCH4 => :yagg, :GDP => :yagg_periodspan)
-    connect_param!(m, :AbatementCostsN2O => :yagg, :GDP => :yagg_periodspan)
-    connect_param!(m, :AbatementCostsLin => :yagg, :GDP => :yagg_periodspan)
+    for allabatement in [
+        (:AbatementCostParametersCO2, :AbatementCostsCO2),
+        (:AbatementCostParametersCH4, :AbatementCostsCH4),
+        (:AbatementCostParametersN2O, :AbatementCostsN2O),
+        (:AbatementCostParametersLin, :AbatementCostsLin)]
+
+        abatementcostparameters, abatementcosts = allabatement
+
+        connect_param!(m, abatementcostparameters => :yagg, :GDP => :yagg_periodspan)
+        connect_param!(m, abatementcostparameters => :cbe_absoluteemissionreductions, :abatementcosts => :cbe_absoluteemissionreductions)
+
+        connect_param!(m, abatementcosts => :zc_zerocostemissions, abatementcostparameters => :zc_zerocostemissions)
+        connect_param!(m, abatementcosts => :q0_absolutecutbacksatnegativecost, abatementcostparameters => :q0_absolutecutbacksatnegativecost)
+        connect_param!(m, abatementcosts => :blo, abatementcostparameters => :blo)
+        connect_param!(m, abatementcosts => :alo, abatementcostparameters => :alo)
+        connect_param!(m, abatementcosts => :bhi, abatementcostparameters => :bhi)
+        connect_param!(m, abatementcosts => :ahi, abatementcostparameters => :ahi)
+
+    end
 
     connect_param!(m, :TotalAbatementCosts => :tc_totalcosts_co2, :AbatementCostsCO2 => :tc_totalcost)
     connect_param!(m, :TotalAbatementCosts => :tc_totalcosts_n2o, :AbatementCostsN2O => :tc_totalcost)

--- a/test/test_AbatementCosts.jl
+++ b/test/test_AbatementCosts.jl
@@ -3,17 +3,23 @@ using DataFrames
 using Test
 
 m = page_model()
+include("../src/components/AbatementCostParameters.jl")
 include("../src/components/AbatementCosts.jl")
 
-addabatementcosts(m, :CO2)
-addabatementcosts(m, :CH4)
-addabatementcosts(m, :N2O)
-addabatementcosts(m, :Lin)
+for gas in [:CO2, :CH4, :N2O, :Lin]
+    abatementcostparameters = addabatementcostparameters(m, gas)
+    abatementcosts = addabatementcosts(m, gas)
 
-set_param!(m, :AbatementCostsCO2, :yagg, readpagedata(m,"test/validationdata/yagg_periodspan.csv"))
-set_param!(m, :AbatementCostsCH4, :yagg, readpagedata(m,"test/validationdata/yagg_periodspan.csv"))
-set_param!(m, :AbatementCostsN2O, :yagg, readpagedata(m,"test/validationdata/yagg_periodspan.csv"))
-set_param!(m, :AbatementCostsLin, :yagg, readpagedata(m,"test/validationdata/yagg_periodspan.csv"))
+    abatementcostparameters[:yagg] = readpagedata(m,"test/validationdata/yagg_periodspan.csv")
+    abatementcostparameters[:cbe_absoluteemissionreductions] = abatementcosts[:cbe_absoluteemissionreductions]
+        
+    abatementcosts[:zc_zerocostemissions] = abatementcostparameters[:zc_zerocostemissions]
+    abatementcosts[:q0_absolutecutbacksatnegativecost] = abatementcostparameters[:q0_absolutecutbacksatnegativecost]
+    abatementcosts[:blo] = abatementcostparameters[:blo]
+    abatementcosts[:alo] = abatementcostparameters[:alo]
+    abatementcosts[:bhi] = abatementcostparameters[:bhi]
+    abatementcosts[:ahi] = abatementcostparameters[:ahi]
+end
 
 p = load_parameters(m)
 p["y_year_0"] = 2008.
@@ -44,7 +50,7 @@ zc_compare_lin=readpagedata(m, "test/validationdata/zc_zerocostemissionsLG.csv")
 @test m[:AbatementCostsN2O, :tc_totalcost] ≈ tc_compare_n2o rtol=1e-2
 @test m[:AbatementCostsLin, :tc_totalcost] ≈ tc_compare_lin rtol=1e-2
 
-@test m[:AbatementCostsCO2, :zc_zerocostemissions] ≈ zc_compare_co2 rtol=1e-2
-@test m[:AbatementCostsCH4, :zc_zerocostemissions] ≈ zc_compare_ch4 rtol=1e-3
-@test m[:AbatementCostsN2O, :zc_zerocostemissions] ≈ zc_compare_n2o rtol=1e-3
-@test m[:AbatementCostsLin, :zc_zerocostemissions] ≈ zc_compare_lin rtol=1e-3
+@test m[:AbatementCostParameters, :zc_zerocostemissions] ≈ zc_compare_co2 rtol=1e-2
+@test m[:AbatementCostParameters, :zc_zerocostemissions] ≈ zc_compare_ch4 rtol=1e-3
+@test m[:AbatementCostParameters, :zc_zerocostemissions] ≈ zc_compare_n2o rtol=1e-3
+@test m[:AbatementCostParameters, :zc_zerocostemissions] ≈ zc_compare_lin rtol=1e-3


### PR DESCRIPTION
There is a natural division in the Abatement Costs component, whereby a large number of parameters get translated into 4 key parameters. Splitting the component at this point also allows the marginal abatement costs to be equated to a tax rate, to determine the emissions reduction process.

This branch is a copy of the branch by @jrising, but has been updated for Julia 1.0 and Mimi v0.6.  It is a work in progress for now, but when finished it can replace that one.