### PR TITLE
Update docs to Documenter.jl v0.21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 docs/build
 .ipynb_checkpoints
+docs/Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,13 @@ script:
 after_success:
   # push coverage results to Codecov
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
-  - julia -e 'using Pkg; Pkg.add("Documenter")'
-  - julia -e 'include("docs/make.jl")'
+
+jobs:
+  include:
+    - stage: "Documentation"
+      julia: 1.0
+      os: linux
+      script:
+        - julia --project=docs/ -e 'using Pkg; Pkg.instantiate()'
+        - julia --project=docs/ --color=yes docs/make.jl
+      after_success: skip

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+
+[compat]
+Documenter = "~0.21"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,8 +1,7 @@
 using Documenter
 
 makedocs(
-	format = :html,
-	sitename = "mimi-page.jl",
+	sitename = "mimi-page-2009.jl",
 	pages = [
 		"Home" => "index.md",
 		"Getting started" => "gettingstarted.md",
@@ -12,9 +11,5 @@ makedocs(
 )
 
 deploydocs(
-    deps = nothing,
-    make = nothing,
-	target = "build",
-    repo = "github.com/anthofflab/mimi-page.jl.git",
-    julia = "0.6"
+    repo = "github.com/anthofflab/mimi-page-2009.jl.git"
 )


### PR DESCRIPTION
First step to fixing https://github.com/anthofflab/mimi-page-2009.jl/issues/167.

In any case, this is how one is supposed to run Documenter.jl now.

I'm going to merge this right away, just wanted to ping @jrising that he sees this :)